### PR TITLE
@orta (cc @gristleism): Web Team Playbook

### DIFF
--- a/web/web.md
+++ b/web/web.md
@@ -1,0 +1,62 @@
+# Web Team Playbook
+
+## Team Information
+
+### Team Goals
+
+* Build and maintain primarily user-facing applications.
+* Support user team goals through web technology.
+* Productivity and developer happiness.
+* Open source by default.
+
+### Who is on the Web Team?
+
+Current members of the Web Team are: [Craig](https://github.com/craigspaeth), [Damon](https://github.com/dzucconi), [Cab](https://github.com/broskoski), [Kana](https://github.com/kanaabe), [Ian](gristleism) and [James](jtotoole).
+
+### Logistics
+
+* Bi-weekly stand-up on Tuesday / Thursday 2:00pm (NYC time)
+  * What are you working on or need help with?
+  * Explain any new features or requests.
+
+* User team meetings
+  * Product team-wide standup and meeting dicussing product progress at a high level.
+  * User team check in on Weds. at 3pm.
+  * User team prioritization meeting beginning of a new sprint at 10:30am.
+
+* Work is done through GitHub issues within sprint cycles.
+  * Sprints restart every 3 weeks.
+  * Issues are created and linked to in the User Team Deck.
+  * [The User Team Deck](https://docs.google.com/presentation/d/18ep3sYGgpIibLFuTn_ANuZbqwaOT1NfuND0BkA3iO8A/edit#slide=id.gafcf7b0f8_3_489) lists each product priority in order of importance under "Sprint Priorities".
+
+* General Chat in [#web](https://artsy.slack.com/messages/web/)
+* Artsy Writer support in [#writer](https://artsy.slack.com/messages/writer/)
+
+### Our Apps
+
+* [Force](https://github.com/artsy/force): The Artsy Desktop Website.
+* [Microgravity](https://github.com/artsy/microgravity): The Artsy Mobile Website.
+* [Positron](https://github.com/artsy/positron): Artsy Writer Editorial Tool.
+* [Europa](https://github.com/artsy/europa) Admin app for Artsy Fair Columns.
+* [Monolith](https://github.com/artsy/monolith) Artsy Fair Columns UI.
+* [Refraction](https://github.com/artsy/refraction) Visualization run at Auctions.
+* [Flare](https://github.com/artsy/flare) Iphone Marketing Website.
+* [folio.artsy.net](https://github.com/artsy/folio.artsy.net) Folio Marketing Website.
+* [2014.artsy.net](https://github.com/artsy/2014.artsy.net) 2014 Year in Review.
+* [artsy-2013](https://github.com/artsy/artsy-2013) 2013 Year in Review.
+
+* See the [engineering projects map](https://trello.com/b/VLlTIM7l/artsy-engineering-projects-map) for a comprehensive list of Mobile Team libraries.
+
+### Our Key Technologies
+
+#### Coffeescript
+
+[Coffeescript](http://coffeescript.org/) is just Javascript with a nicer syntax that attempts to expose [The Good Parts](http://www.amazon.com/JavaScript-Good-Parts-Douglas-Crockford/dp/0596517742).
+
+#### Node.js
+
+[Node.js](https://nodejs.org/) brings Javascript (and to-JS languages like Coffeescript) to the server-side.
+
+#### Ezel
+
+[Ezel](https://github.com/artsy/ezel) is a combination of tools and patterns Artsy released as a boilerplate project generator. It combines [Backbone](http://backbonejs.org/), [Express](http://expressjs.com/) and [Browserify](http://browserify.org/) in a way that makes it easy to do ["Isomorphic Javascript"](http://nerds.airbnb.com/isomorphic-javascript-future-web-apps/)-ey things.


### PR DESCRIPTION
Adds the on-boarding docs for Web Team.